### PR TITLE
feat(#27): 공통 버튼 컴포넌트(Button) 생성, cn 함수 정의

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.3",
+        "class-variance-authority": "^0.7.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.5.0"
+        "react-router-dom": "^7.5.0",
+        "swiper": "^11.2.8",
+        "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.8",
@@ -2481,6 +2484,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5883,6 +5907,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swiper": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.8.tgz",
+      "integrity": "sha512-S5FVf6zWynPWooi7pJ7lZhSUe2snTzqLuUzbd5h5PHUOhzgvW0bLKBd2wv0ixn6/5o9vwc/IkQT74CRcLJQzeg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.3.tgz",
@@ -5898,6 +5941,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.3",
+    "class-variance-authority": "^0.7.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.5.0"
+    "react-router-dom": "^7.5.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.8",

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,56 @@
+import '@/styles/button.css';
+import { cn } from '@/utils/style';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  type?: 'button' | 'submit' | 'reset';
+  href?: string;
+  children: React.ReactNode;
+  className?: string;
+  variant?: 'filled' | 'outlined' | 'white-outlined';
+  size?: 'lg' | 'xl';
+}
+const baseClass = 'btn';
+const sizeMap = {
+  lg: 'btn-lg',
+  xl: 'btn-xl',
+};
+const variantMap = {
+  filled: 'btn-filled',
+  outlined: 'btn-outlined',
+  'white-outlined': 'btn-white-outlined',
+};
+
+const Button = ({
+  children,
+  href,
+  type,
+  className,
+  variant = 'filled',
+  size = 'lg',
+  ...rest
+}: ButtonProps) => {
+  const finalClass = cn(
+    baseClass,
+    sizeMap[size],
+    variantMap[variant],
+    className,
+  );
+
+  if (href) {
+    return (
+      <Link to={href} className={finalClass}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button type={type} className={finalClass} {...rest}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -1,0 +1,24 @@
+@import "tailwindcss";
+
+.btn {
+    @apply inline-flex items-center justify-center font-medium transition-colors duration-200 leading-6 cursor-pointer;
+}
+.btn-lg {
+  @apply rounded-md py-4 px-14;
+}
+
+.btn-xl {
+    @apply rounded-lg py-3 px-16;
+}
+
+.btn-filled {
+  @apply bg-black text-white hover:bg-neutral-800;
+}
+
+.btn-outlined {
+  @apply border border-black text-black hover:bg-neutral-100;
+}
+
+.btn-white-outlined {
+  @apply border-white bg-transparent text-white border hover:bg-[#ffffff1a];
+}

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,0 +1,9 @@
+import { cx } from 'class-variance-authority';
+import { ClassValue } from 'class-variance-authority/types';
+import { twMerge } from 'tailwind-merge';
+
+// utils에서 전체 관리
+export * from 'class-variance-authority';
+
+// twMerge와 cx 병합함수
+export const cn = (...args: ClassValue[]) => twMerge(cx(...args));


### PR DESCRIPTION
## 🔧 관련 이슈
- 이 PR은 **#27**에 관련됩니다. 

## 🔄 변경 사항
- [x] 기능 추가
- [x] 스타일 수정

## ✔️ 변경 사항 내용
- 공통 버튼 컴포넌트(Button) 생성
  - variant: filled, outlined, white-outlined 스타일 지원
  - size: lg, xl 버튼 크기 적용
  - className은 유틸 함수 cn으로 병합 처리
  - href가 있을 경우 React Router의 <Link>로 렌더링, 없을 경우 <button> 사용

- class-variance-authority(cx)와 tailwind-merge(twMerge)를 결합한 cn 함수 정의
  - 조건부 클래스 표현 및 중복된 Tailwind 유틸 제거 처리
  - 공통 유틸로 사용 가능하도록 utils에서 export 처리
